### PR TITLE
Fixes for windows

### DIFF
--- a/samples/poc/build-hl-win.cmd
+++ b/samples/poc/build-hl-win.cmd
@@ -1,1 +1,2 @@
 haxe -D ammer.hl.hlInclude=%HLPATH%/include -D ammer.hl.hlLibrary=%HLPATH% build-hl.hxml 
+copy native\adder.dll bin\hl\

--- a/samples/poc/build-hl-win.cmd
+++ b/samples/poc/build-hl-win.cmd
@@ -1,0 +1,1 @@
+haxe -D ammer.hl.hlInclude=%HLPATH%/include -D ammer.hl.hlLibrary=%HLPATH% build-hl.hxml 

--- a/samples/poc/build-native.cmd
+++ b/samples/poc/build-native.cmd
@@ -1,0 +1,2 @@
+cd native
+nmake Makefile.win

--- a/samples/poc/run-hl-win.cmd
+++ b/samples/poc/run-hl-win.cmd
@@ -1,0 +1,4 @@
+copy native/adder.dll bin/hl
+copy dummy.txt bin\hl
+cd bin/hl
+hl sample.hl

--- a/src/ammer/build/BuildTools.hx
+++ b/src/ammer/build/BuildTools.hx
@@ -47,7 +47,7 @@ class BuildTools {
               lb.ai('cp ${e.requires[0]} ${e.target}');
             case CompileObjectC(opt):
               if (Ammer.config.useMSVC) {
-                lb.ai('${Ammer.config.pathMSVC}cl /OUT:${e.target} /c ${e.requires.join(" ")}');
+                lb.ai('${Ammer.config.pathMSVC}cl /Fe:${e.target} /c ${e.requires.join(" ")}');
                 for (path in opt.includePaths)
                   lb.a(' /I "$path"');
               } else {
@@ -57,7 +57,7 @@ class BuildTools {
               }
             case CompileObjectCpp(opt):
               if (Ammer.config.useMSVC) {
-                lb.ai('${Ammer.config.pathMSVC}cl /OUT:${e.target} /c ${e.requires.join(" ")}');
+                lb.ai('${Ammer.config.pathMSVC}cl /Fe:${e.target} /c ${e.requires.join(" ")}');
                 for (path in opt.includePaths)
                   lb.a(' /I "$path"');
               } else {
@@ -67,7 +67,7 @@ class BuildTools {
               }
             case LinkLibrary(opt):
               if (Ammer.config.useMSVC) {
-                lb.ai('${Ammer.config.pathMSVC}cl /OUT:${e.target} /LD ${e.requires.join(" ")}');
+                lb.ai('${Ammer.config.pathMSVC}cl /Fe:${e.target} /LD ${e.requires.join(" ")}');
                 for (d in opt.defines)
                   lb.a(' /D$d');
                 lb.a(' /link');
@@ -148,7 +148,7 @@ class BuildTools {
               File.copy(e.requires[0], e.target);
             case CompileObjectC(opt):
               if (Ammer.config.useMSVC) {
-                var args = ['/OUT:${e.target}', "/c"];
+                var args = ['/Fe:${e.target}', "/c"];
                 for (req in e.requires)
                   args.push(req);
                 for (path in opt.includePaths) {
@@ -168,7 +168,7 @@ class BuildTools {
               }
             case CompileObjectCpp(opt):
               if (Ammer.config.useMSVC) {
-                var args = ['/OUT:${e.target}', "/c"];
+                var args = ['/Fe:${e.target}', "/c"];
                 for (req in e.requires)
                   args.push(req);
                 for (path in opt.includePaths) {
@@ -188,7 +188,7 @@ class BuildTools {
               }
             case LinkLibrary(opt):
               if (Ammer.config.useMSVC) {
-                var args = ['/OUT:${e.target}', "/LD"];
+                var args = ['/Fe:${e.target}', "/LD"];
                 for (req in e.requires)
                   args.push(req);
                 for (d in opt.defines)

--- a/tests/native/Makefile.win
+++ b/tests/native/Makefile.win
@@ -16,6 +16,6 @@ templates.obj: templates.cpp
 	cl /c templates.cpp
 
 tmp.native.h: native.h
-	cp native.h tmp.native.h
+	copy native.h tmp.native.h
 
 .PHONY: all

--- a/tests/test-windows.bat
+++ b/tests/test-windows.bat
@@ -28,10 +28,12 @@ IF %ERRORLEVEL% NEQ 0 ( echo "build of cpp tests failed" && goto :eval)
 cd bin\cpp
 copy ..\..\native\native.dll .
 Main.exe
-IF %ERRORLEVEL% NEQ 0 ( echo "cpp tests failed" && goto :eval)
 cd ../..
+IF %ERRORLEVEL% NEQ 0 ( echo "cpp tests failed" && goto :eval)
+
 
 :eval
+
 
 echo "testing eval ..."
 copy native\native.dll .

--- a/tests/test-windows.bat
+++ b/tests/test-windows.bat
@@ -1,28 +1,39 @@
-rem @echo off
+@echo off
+
 
 echo "building native library ..."
 cd native
 nmake /f Makefile.win
 cd ..
 
+
 echo "testing hl ..."
-haxe build-hl.hxml
-if errorrlevel 0 (
-    cd bin/hl
-    copy ../../native/native.dll .
-    hl test.hl
-    cd ../..
-)
+haxe -D ammer.hl.hlInclude=%HLPATH%/include -D ammer.hl.hlLibrary=%HLPATH% build-hl.hxml
+IF %ERRORLEVEL% NEQ 0 ( echo "build of hl tests failed" && goto :cpp)
+pushd bin\hl
+copy ..\..\native\native.dll .
+hl test.hl
+popd
+IF %ERRORLEVEL% NEQ 0 ( echo "hl tests failed" && goto :cpp)
+
+
+:cpp
 
 echo "testing cpp ..."
+rd /q /s bin\cpp
+
 haxe build-cpp.hxml
-if errorrlevel 0 (
-    cd bin/cpp
-    copy ../../native/native.dll .
-    ./Main
-    cd ../..
-)
+IF %ERRORLEVEL% NEQ 0 ( echo "build of cpp tests failed" && goto :eval)
+
+cd bin\cpp
+copy ..\..\native\native.dll .
+Main.exe
+IF %ERRORLEVEL% NEQ 0 ( echo "cpp tests failed" && goto :eval)
+cd ../..
+
+:eval
 
 echo "testing eval ..."
-copy native/native.dll .
-haxe -D ammer.eval.hxDir=%TEST_HXDIR% build-cpp.hxml
+copy native\native.dll .
+haxe -D ammer.eval.haxeDir=%HAXEPATH% build-eval.hxml
+IF %ERRORLEVEL% NEQ 0 ( echo "eval tests failed")

--- a/tests/test-windows.bat
+++ b/tests/test-windows.bat
@@ -1,4 +1,4 @@
-@echo off
+rem @echo off
 
 echo "building native library ..."
 cd native
@@ -9,7 +9,7 @@ echo "testing hl ..."
 haxe build-hl.hxml
 if errorrlevel 0 (
     cd bin/hl
-    cp ../../native/native.dll .
+    copy ../../native/native.dll .
     hl test.hl
     cd ../..
 )
@@ -18,11 +18,11 @@ echo "testing cpp ..."
 haxe build-cpp.hxml
 if errorrlevel 0 (
     cd bin/cpp
-    cp ../../native/native.dll .
+    copy ../../native/native.dll .
     ./Main
     cd ../..
 )
 
 echo "testing eval ..."
-cp native/native.dll .
+copy native/native.dll .
 haxe -D ammer.eval.hxDir=%TEST_HXDIR% build-cpp.hxml


### PR DESCRIPTION
#44 related. As for building on windows, I have following results:
1. Sample project builds and runs fine (hl target) with batch scripts. Call under vcvars and make sure %HLPATH% is set and point to folder with hl. (1.10 in my case it's last 32 bit release).
2. Test launcher for windows (test-windows.bat ) do what it should – builds and calls tests.
2.1 test under hl fails with
`src\module.c(465) : FATAL ERROR : Invalid signature for function ammer_native@w__ammer_externs_AmmerArray_0_AmmerArray_0_ofNativeInt : POBi__Xwt_array_0_0_ required but POiBi__Xwt_array_0_0_ found in hdll`
2.2 Linking cpp test fails with
`native.obj : error LNK2019: unresolved external symbol _utf8_decode referenced in function _rev_string`
But if body of `rev_string()` in `native.c` is commented out then 171 out of 173 assertion is succeeded.
2.3 Test on eval fails with exception `Ammer.hx:572: characters 13-18 : Uncaught exception !`
3. the PR is also contains fix for MSVC compiler flags.